### PR TITLE
Support multiple readers in the mapping-template component

### DIFF
--- a/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
+++ b/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-graph",
-    "version": "4.1.1-SNAPSHOT",
+    "version": "4.1.1",
     "scheme": "graph",
     "extendsScheme": "",
     "syntax": "graph:name",

--- a/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
+++ b/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-graph",
-    "version": "4.1.1",
+    "version": "4.1.2-SNAPSHOT",
     "scheme": "graph",
     "extendsScheme": "",
     "syntax": "graph:name",

--- a/camel-chimera-graph/src/main/java/com/cefriel/util/Utils.java
+++ b/camel-chimera-graph/src/main/java/com/cefriel/util/Utils.java
@@ -148,8 +148,7 @@ public class Utils {
             if(resourceQuery != null)
                 LOG.info("Two queries have been supplied to the operation. Using the 'query' endpoint parameter supplied query.");
             return literalQuery;
-        } else if (resourceQuery != null)
-        {
+        } else if (resourceQuery != null) {
             ByteArrayOutputStream o;
             try (InputStream inputstream = ResourceAccessor.open(resourceQuery, exchange)) {
                 o = new ByteArrayOutputStream();
@@ -161,7 +160,6 @@ public class Utils {
             throw new NullPointerException("both queries query cannot be null");
         }
     }
-
     public static String writeModelToDestination(Exchange exchange, Model model, String defaultName) throws IOException {
         GraphBean configuration = exchange.getMessage().getHeader(ChimeraConstants.CONFIGURATION, GraphBean.class);
         InputStream inputStream = RDFSerializer.serialize(model, exchange);

--- a/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
+++ b/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-mapping-template",
-    "version": "4.1.1",
+    "version": "4.1.2-SNAPSHOT",
     "scheme": "mapt",
     "extendsScheme": "",
     "syntax": "mapt:name",

--- a/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
+++ b/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-mapping-template",
-    "version": "4.1.1-SNAPSHOT",
+    "version": "4.1.1",
     "scheme": "mapt",
     "extendsScheme": "",
     "syntax": "mapt:name",

--- a/camel-chimera-mapping-template/src/main/java/com/cefriel/component/MaptTemplateProducer.java
+++ b/camel-chimera-mapping-template/src/main/java/com/cefriel/component/MaptTemplateProducer.java
@@ -51,7 +51,7 @@ public class  MaptTemplateProducer extends DefaultProducer {
         if (this.templateExecutor == null) {
             // check if the input format for the readers is supported
             if (Set.of("rdf", "xml", "json", "csv", "readers", "").contains(endpoint.getName())) {
-                this.templateExecutor = MaptTemplateProcessor.templateExecutor(exchange, operationConfig, endpoint.getName());
+                this.templateExecutor = MaptTemplateProcessor.templateExecutor(exchange, operationConfig);
                 MaptTemplateProcessor.execute(exchange, operationConfig, endpoint.getName(), this.templateExecutor);
             }
             else

--- a/camel-chimera-mapping-template/src/main/java/com/cefriel/component/MaptTemplateProducer.java
+++ b/camel-chimera-mapping-template/src/main/java/com/cefriel/component/MaptTemplateProducer.java
@@ -23,7 +23,7 @@ import org.apache.camel.support.DefaultProducer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class MaptTemplateProducer extends DefaultProducer {
+public class  MaptTemplateProducer extends DefaultProducer {
     private static final Logger LOG = LoggerFactory.getLogger(MaptTemplateProducer.class);
     private final MaptTemplateEndpoint endpoint;
 
@@ -48,6 +48,7 @@ public class MaptTemplateProducer extends DefaultProducer {
             case "xml" -> MaptTemplateProcessor.execute(exchange, operationConfig, "xml");
             case "json" -> MaptTemplateProcessor.execute(exchange, operationConfig, "json");
             case "csv" -> MaptTemplateProcessor.execute(exchange, operationConfig, "csv");
+            case "readers" -> MaptTemplateProcessor.execute(exchange, operationConfig, "readers");
             case "" -> MaptTemplateProcessor.execute(exchange, operationConfig, null);
             default -> throw new IllegalArgumentException("Invalid INPUT FORMAT: " + endpoint.getName());
         }

--- a/camel-chimera-mapping-template/src/main/java/com/cefriel/rdf/MaptTemplateProcessor.java
+++ b/camel-chimera-mapping-template/src/main/java/com/cefriel/rdf/MaptTemplateProcessor.java
@@ -170,7 +170,7 @@ public class MaptTemplateProcessor {
                 if(params.query() != null) {
                     List<Path> resultFilesPaths;
                     if (reader != null) {
-                        resultFilesPaths = templateExecutor.executeMappingParametric(reader,
+                        resultFilesPaths = templateExecutor.executeMappingParametric(Map.of("reader", reader),
                                 ResourceAccessor.open(params.template(), exchange),
                                 ResourceAccessor.open(params.query(), exchange),
                                 outputFilePath);
@@ -186,7 +186,7 @@ public class MaptTemplateProcessor {
                 } else {
                     Path resultFilePath;
                     if (reader != null) {
-                        resultFilePath = templateExecutor.executeMapping(reader, ResourceAccessor.open(params.template(), exchange), outputFilePath);
+                        resultFilePath = templateExecutor.executeMapping(Map.of("reader", reader), ResourceAccessor.open(params.template(), exchange), outputFilePath);
                     }
                     else {
                         resultFilePath = templateExecutor.executeMapping(readers, ResourceAccessor.open(params.template(), exchange), outputFilePath);
@@ -200,7 +200,7 @@ public class MaptTemplateProcessor {
                 if (params.query() != null) {
                     Map<String,String> result;
                     if (reader != null) {
-                        result = templateExecutor.executeMappingParametric(reader,
+                        result = templateExecutor.executeMappingParametric(Map.of("reader", reader),
                                 ResourceAccessor.open(params.template(), exchange),
                                 ResourceAccessor.open(params.query(), exchange));
                     }
@@ -214,7 +214,7 @@ public class MaptTemplateProcessor {
                 } else {
                     String result;
                     if (reader != null) {
-                        result = templateExecutor.executeMapping(reader, ResourceAccessor.open(params.template(), exchange));
+                        result = templateExecutor.executeMapping(Map.of("reader", reader), ResourceAccessor.open(params.template(), exchange));
                     }
                     else {
                         result = templateExecutor.executeMapping(readers, ResourceAccessor.open(params.template(), exchange));

--- a/camel-chimera-mapping-template/src/main/java/com/cefriel/rdf/MaptTemplateProcessor.java
+++ b/camel-chimera-mapping-template/src/main/java/com/cefriel/rdf/MaptTemplateProcessor.java
@@ -91,13 +91,13 @@ public class MaptTemplateProcessor {
         return true;
     }
 
-    public static TemplateExecutor templateExecutor(Exchange exchange, MaptTemplateBean operationConfig, String inputFormat) throws Exception {
+    public static TemplateExecutor templateExecutor(Exchange exchange, MaptTemplateBean operationConfig) throws Exception {
         OperationParams params = getOperationParams(exchange, operationConfig);
-        return templateExecutor(params, exchange, inputFormat);
+        return templateExecutor(params, exchange);
 
     }
 
-    private static TemplateExecutor templateExecutor(OperationParams params, Exchange exchange, String inputFormat) throws Exception {
+    private static TemplateExecutor templateExecutor(OperationParams params, Exchange exchange) throws Exception {
         // which custom template functions to use ???
         // the one that is defined, what if both are defined?
         // throw a warning

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptMultipleReadersTest.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptMultipleReadersTest.java
@@ -1,0 +1,64 @@
+package com.cefriel;
+
+import com.cefriel.template.io.Reader;
+import com.cefriel.template.io.csv.CSVReader;
+import com.cefriel.util.ChimeraResourceBean;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+public class MaptMultipleReadersTest extends CamelTestSupport {
+    @Produce("direct:start")
+    ProducerTemplate start;
+
+    private static ChimeraResourceBean templateMultipleReaders;
+
+    @BeforeAll
+    static void fillBeans(){
+        templateMultipleReaders = new ChimeraResourceBean(
+                "file://./src/test/resources/file/multiple-readers/template.vm",
+                "");
+    }
+
+    @Test
+    public void testMultipleReaders() throws InterruptedException {
+        MockEndpoint mock = getMockEndpoint("mock:multipleReaders");
+        mock.expectedMessageCount(1);
+
+        Map<String, Reader> readers = Map.of("reader1",
+                new CSVReader("""
+                        a,b,c
+                        1,2,3
+                        """),
+                "reader2",
+                new CSVReader("""
+                        d,e,f
+                        4,5,6
+                        """));
+        start.sendBody(readers);
+        String result = mock.getExchanges().get(0).getMessage().getBody(String.class);
+        String expectedOutput = "1,2,3,4,5,6".replaceAll("\\r\\n", "\n");
+        assert expectedOutput.equals(result);
+        mock.assertIsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception{
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+
+                getCamelContext().getRegistry().bind("templateMultipleReaders", templateMultipleReaders);
+                from("direct:start")
+                        .to("mapt://readers?template=#bean:templateMultipleReaders")
+                        .to("mock:multipleReaders");
+            }
+        };
+    }
+}

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateAgencyTest.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateAgencyTest.java
@@ -52,7 +52,6 @@ public class MaptTemplateAgencyTest extends CamelTestSupport {
 
     @Test
     public void testRdfTemplateAgency() throws Exception {
-
         MockEndpoint mock = getMockEndpoint("mock:rdfAgency");
         mock.expectedMessageCount(1);
         mock.assertIsSatisfied();
@@ -60,7 +59,6 @@ public class MaptTemplateAgencyTest extends CamelTestSupport {
 
     @Test
     public void testRdfMultipleTemplateAgency() throws Exception {
-
         MockEndpoint mock = getMockEndpoint("mock:rdfMultipleAgency");
         mock.expectedMessageCount(1);
         ChimeraResourceBean file = new ChimeraResourceBean(
@@ -75,7 +73,6 @@ public class MaptTemplateAgencyTest extends CamelTestSupport {
         return new RouteBuilder() {
             @Override
             public void configure() throws Exception {
-
                 getCamelContext().getRegistry().bind("triples", triples);
                 getCamelContext().getRegistry().bind("template", template);
                 getCamelContext().getRegistry().bind("triples2", triples2);

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateCsvTest.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateCsvTest.java
@@ -54,12 +54,11 @@ public class MaptTemplateCsvTest extends CamelTestSupport {
 
         ChimeraResourceBean r = new ChimeraResourceBean("file://./src/test/resources/file/csv/example.csv", "csv");
         start.sendBody(ResourceAccessor.open(r, null));
-
         mock.assertIsSatisfied();
-        long filesEqual = Files.mismatch(Paths.get("./src/test/resources/file/csv/output-correct.ttl"),
-                Paths.get(("./src/test/resources/file/result/output-csv.ttl")));
-        boolean correctOutput = filesEqual == -1;
-        assert (correctOutput);
+
+        String correctOutput = Files.readString(Paths.get("./src/test/resources/file/csv/output-correct.ttl"));
+        String mappedOutput = Files.readString(Paths.get("./src/test/resources/file/result/output-csv.ttl"));
+        assert(TestUtils.isIsomorphicGraph(correctOutput, "turtle", mappedOutput, "turtle"));
     }
 
     @Test
@@ -67,14 +66,12 @@ public class MaptTemplateCsvTest extends CamelTestSupport {
         MockEndpoint mock = getMockEndpoint("mock:rdfCsvNoInput");
         mock.expectedMessageCount(1);
 
-        // ChimeraResourceBean r = new ChimeraResourceBean("file://./src/test/resources/file/csv/example.csv", "csv");
-        // foo.sendBody(ResourceAccessor.open(r, camelTestSupportExtension.context()));
         foo.send(ExchangeBuilder.anExchange(context()).build());
         mock.assertIsSatisfied();
-        long filesEqual = Files.mismatch(Paths.get("./src/test/resources/file/csv/output-correct.ttl"),
-                Paths.get(("./src/test/resources/file/result/output-csv-no-input.ttl")));
-        boolean correctOutput = filesEqual == -1;
-        assert (correctOutput);
+
+        String correctOutput = Files.readString(Paths.get("./src/test/resources/file/csv/output-correct.ttl"));
+        String mappedOutput = Files.readString(Paths.get("./src/test/resources/file/result/output-csv-no-input.ttl"));
+        assert(TestUtils.isIsomorphicGraph(correctOutput, "turtle", mappedOutput, "turtle"));
     }
 
     @Override

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateParametricAgencyTest.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateParametricAgencyTest.java
@@ -45,13 +45,14 @@ public class MaptTemplateParametricAgencyTest extends CamelTestSupport {
         mock.expectedMessageCount(1);
         mock.assertIsSatisfied();
         List<Path> resultsFilesPaths = mock.getExchanges().get(0).getMessage().getBody(List.class);
-        String correctOutput1 = Files.readString(Paths.get("./src/test/resources/file/agency-parametric/agency-BEST-AGENCY.csv")).replaceAll("\\r\\n", "\n");
-        String obtainedOutput1 = Files.readString(resultsFilesPaths.get(0)).replaceAll("\\r\\n", "\n");
-        assert (correctOutput1.equals(obtainedOutput1));
 
-        String correctOutput2 = Files.readString(Paths.get("./src/test/resources/file/agency-parametric/agency-WOW-AGENCY.csv")).replaceAll("\\r\\n", "\n");
-        String obtainedOutput2 = Files.readString(resultsFilesPaths.get(1)).replaceAll("\\r\\n", "\n");
-        assert (correctOutput2.equals(obtainedOutput2));
+        String correctOutput = Files.readString(Paths.get("./src/test/resources/file/agency-parametric/agency-BEST-AGENCY.csv"));
+        String mappedOutput = Files.readString(resultsFilesPaths.get(0));
+        assert(TestUtils.isIsomorphicGraph(correctOutput, "turtle", mappedOutput, "turtle"));
+
+        String correctOutput1 = Files.readString(Paths.get("./src/test/resources/file/agency-parametric/agency-WOW-AGENCY.csv"));
+        String mappedOutput1 = Files.readString(resultsFilesPaths.get(1));
+        assert(TestUtils.isIsomorphicGraph(correctOutput1, "turtle", mappedOutput1, "turtle"));
     }
 
     @Override

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateXmlTest.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptTemplateXmlTest.java
@@ -48,10 +48,11 @@ public class MaptTemplateXmlTest extends CamelTestSupport {
         start.sendBody(ResourceAccessor.open(r, null));
 
         mock.assertIsSatisfied();
-        long filesEqual = Files.mismatch(Paths.get("./src/test/resources/file/xml/output-correct.ttl"),
-                Paths.get(("./src/test/resources/file/result/output-xml.ttl")));
-        boolean correctOutput = filesEqual == -1;
-        assert (correctOutput);
+
+        String correctOutput = Files.readString(Paths.get("./src/test/resources/file/xml/output-correct.ttl"));
+        String mappedOutput = Files.readString(Paths.get("./src/test/resources/file/result/output-xml.ttl"));
+
+        assert(TestUtils.isIsomorphicGraph(correctOutput, "turtle", mappedOutput, "turtle"));
     }
 
     @Override

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/TestUtils.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/TestUtils.java
@@ -1,0 +1,32 @@
+package com.cefriel;
+
+import com.cefriel.util.Utils;
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.model.impl.TreeModel;
+import org.eclipse.rdf4j.model.util.Models;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParser;
+import org.eclipse.rdf4j.rio.Rio;
+import org.eclipse.rdf4j.rio.helpers.StatementCollector;
+
+import java.io.StringReader;
+
+public class TestUtils {
+
+    public static boolean isIsomorphicGraph(String rdfString, String rdfStringFormat,
+                                             String otherRdfString, String otherRdfStringFormat) throws Exception {
+        Model a = parseRDFString(rdfString, rdfStringFormat);
+        Model b = parseRDFString(otherRdfString, otherRdfStringFormat);
+        return Models.isomorphic(a,b);
+    }
+
+    public static Model parseRDFString(String rdfString, String rdfFormat) throws Exception {
+        RDFFormat format = Utils.getRDFFormat(rdfFormat);
+        RDFParser rdfParser = Rio.createParser(format);
+
+        Model model = new TreeModel();
+        rdfParser.setRDFHandler(new StatementCollector(model));
+        // rdfParser.parse(new StringReader(rdfString), "http://example.com/base/");
+        return model;
+    }
+}

--- a/camel-chimera-mapping-template/src/test/resources/file/multiple-readers/template.vm
+++ b/camel-chimera-mapping-template/src/test/resources/file/multiple-readers/template.vm
@@ -1,3 +1,3 @@
-#set ($df1 = $readers.reader1.getDataframe())
-#set ($df2 = $readers["reader2"].getDataframe())
+#set ($df1 = $reader1.getDataframe())
+#set ($df2 = $reader2.getDataframe())
 $df1[0].a,$df1[0].b,$df1[0].c,$df2[0].d,$df2[0].e,$df2[0].f

--- a/camel-chimera-mapping-template/src/test/resources/file/multiple-readers/template.vm
+++ b/camel-chimera-mapping-template/src/test/resources/file/multiple-readers/template.vm
@@ -1,0 +1,3 @@
+#set ($df1 = $readers.reader1.getDataframe())
+#set ($df2 = $readers["reader2"].getDataframe())
+$df1[0].a,$df1[0].b,$df1[0].c,$df2[0].d,$df2[0].e,$df2[0].f

--- a/camel-chimera-mapping-template/src/test/resources/file/result/output-xml.ttl
+++ b/camel-chimera-mapping-template/src/test/resources/file/result/output-xml.ttl
@@ -6,8 +6,8 @@
 
 
 ex:25 rdf:type transit:stop ;
-  transit:stop "645"^^xsd:int ;
-  rdfs:label "International Airport" .
-ex:25 rdf:type transit:stop ;
   transit:stop "651"^^xsd:int ;
   rdfs:label "Conference center" .
+ex:25 rdf:type transit:stop ;
+  transit:stop "645"^^xsd:int ;
+  rdfs:label "International Airport" .

--- a/camel-chimera-mapping-template/src/test/resources/file/xml/output-correct.ttl
+++ b/camel-chimera-mapping-template/src/test/resources/file/xml/output-correct.ttl
@@ -6,8 +6,8 @@
 
 
 ex:25 rdf:type transit:stop ;
-  transit:stop "645"^^xsd:int ;
-  rdfs:label "International Airport" .
-ex:25 rdf:type transit:stop ;
   transit:stop "651"^^xsd:int ;
   rdfs:label "Conference center" .
+ex:25 rdf:type transit:stop ;
+  transit:stop "645"^^xsd:int ;
+  rdfs:label "International Airport" .

--- a/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
+++ b/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-rmlmapper",
-    "version": "4.1.1-SNAPSHOT",
+    "version": "4.1.1",
     "scheme": "rml",
     "extendsScheme": "",
     "syntax": "rml:name",

--- a/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
+++ b/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-rmlmapper",
-    "version": "4.1.1",
+    "version": "4.1.2-SNAPSHOT",
     "scheme": "rml",
     "extendsScheme": "",
     "syntax": "rml:name",

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <camel.version>4.4.1</camel.version>
     <rdf4j.version>4.3.10</rdf4j.version>
-    <mapping-template.version>2.5.2-SNAPSHOT</mapping-template.version>
+    <mapping-template.version>2.5.2</mapping-template.version>
     <rmlmapper.version>1.1.0</rmlmapper.version>
     <camel-test-junit.version>${camel.version}</camel-test-junit.version>
     <camel-bom.version>${camel.version}</camel-bom.version>

--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
   <properties>
     <camel.version>4.4.1</camel.version>
     <rdf4j.version>4.3.10</rdf4j.version>
-    <mapping-template.version>2.5.1</mapping-template.version>
+    <mapping-template.version>2.5.2-SNAPSHOT</mapping-template.version>
     <rmlmapper.version>1.1.0</rmlmapper.version>
     <camel-test-junit.version>${camel.version}</camel-test-junit.version>
     <camel-bom.version>${camel.version}</camel-bom.version>


### PR DESCRIPTION
Adds an endpoint to the mapping template component _"mapt://readers?..."_ that expects as input an exchange whose body contains a `Map<String,Reader>` of `Readers`.

If accepted, it should be merged only after https://github.com/cefriel/mapping-template/pull/27.