### PR TITLE
fix: creation of mapt singleton TemplateExecutor

### DIFF
--- a/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
+++ b/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-graph",
-    "version": "4.1.2-SNAPSHOT",
+    "version": "4.2.1-SNAPSHOT",
     "scheme": "graph",
     "extendsScheme": "",
     "syntax": "graph:name",

--- a/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
+++ b/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-mapping-template",
-    "version": "4.1.2-SNAPSHOT",
+    "version": "4.2.1-SNAPSHOT",
     "scheme": "mapt",
     "extendsScheme": "",
     "syntax": "mapt:name",

--- a/camel-chimera-mapping-template/src/main/java/com/cefriel/component/MaptTemplateProducer.java
+++ b/camel-chimera-mapping-template/src/main/java/com/cefriel/component/MaptTemplateProducer.java
@@ -48,14 +48,16 @@ public class  MaptTemplateProducer extends DefaultProducer {
         }
         operationConfig.setConfig(endpoint);
 
-        if (this.templateExecutor == null) {
-            // check if the input format for the readers is supported
-            if (Set.of("rdf", "xml", "json", "csv", "readers", "").contains(endpoint.getName())) {
+        if (Set.of("rdf", "xml", "json", "csv", "readers", "").contains(endpoint.getName())) {
+            if (this.templateExecutor == null) {
+                //set templateExecutor if first invocation
                 this.templateExecutor = MaptTemplateProcessor.templateExecutor(exchange, operationConfig);
-                MaptTemplateProcessor.execute(exchange, operationConfig, endpoint.getName(), this.templateExecutor);
             }
-            else
-                throw new IllegalArgumentException("Invalid INPUT FORMAT: " + endpoint.getName());
+            MaptTemplateProcessor.execute(exchange, operationConfig, endpoint.getName(), this.templateExecutor);
         }
+        else
+            throw new IllegalArgumentException("Invalid INPUT FORMAT: " + endpoint.getName());
+
+
     }
 }

--- a/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
+++ b/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-rmlmapper",
-    "version": "4.1.2-SNAPSHOT",
+    "version": "4.2.1-SNAPSHOT",
     "scheme": "rml",
     "extendsScheme": "",
     "syntax": "rml:name",


### PR DESCRIPTION
Fixes the creation logic for the TemplateExecutor used to run MTL mappings. Previously, due to faulty logic in the the if statement the second time that the same mapping-template component object would be used the template process would not be called, leading to incorrect behaviour where the input exchange body would be returned as is by the mapping-template component.