### PR TITLE
Add multiple readers aggregation strategy

### DIFF
--- a/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
+++ b/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-graph",
-    "version": "4.3.0",
+    "version": "4.3.1-SNAPSHOT",
     "scheme": "graph",
     "extendsScheme": "",
     "syntax": "graph:name",

--- a/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
+++ b/camel-chimera-graph/src/generated/resources/com/cefriel/component/graph.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-graph",
-    "version": "4.2.2-SNAPSHOT",
+    "version": "4.3.0",
     "scheme": "graph",
     "extendsScheme": "",
     "syntax": "graph:name",

--- a/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
+++ b/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-mapping-template",
-    "version": "4.3.0",
+    "version": "4.3.1-SNAPSHOT",
     "scheme": "mapt",
     "extendsScheme": "",
     "syntax": "mapt:name",

--- a/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
+++ b/camel-chimera-mapping-template/src/generated/resources/com/cefriel/component/mapt.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-mapping-template",
-    "version": "4.2.2-SNAPSHOT",
+    "version": "4.3.0",
     "scheme": "mapt",
     "extendsScheme": "",
     "syntax": "mapt:name",

--- a/camel-chimera-mapping-template/src/main/java/com/cefriel/aggregationStrategy/ReadersAggregation.java
+++ b/camel-chimera-mapping-template/src/main/java/com/cefriel/aggregationStrategy/ReadersAggregation.java
@@ -1,0 +1,93 @@
+package com.cefriel.aggregationStrategy;
+
+import com.cefriel.template.io.Reader;
+import com.cefriel.template.io.csv.CSVReader;
+import com.cefriel.template.io.json.JSONReader;
+import com.cefriel.template.io.rdf.RDFReader;
+import com.cefriel.template.io.sql.SQLReader;
+import com.cefriel.template.io.xml.XMLReader;
+import org.apache.camel.AggregationStrategy;
+import org.apache.camel.Exchange;
+import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
+import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.Rio;
+
+import java.io.IOException;
+import java.security.InvalidParameterException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+public class ReadersAggregation implements AggregationStrategy {
+
+    @Override
+    public Exchange aggregate(Exchange oldExchange, Exchange newExchange) {
+        if (oldExchange == null) {
+            try {
+                newExchange.getMessage().setBody(getReaders(newExchange));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return newExchange;
+        }
+
+        Map<String, Reader> oldReaders = (Map<String, Reader>) oldExchange.getMessage().getBody();
+        Map<String, Reader> newReaders = null;
+        try {
+            newReaders = getReaders(newExchange);
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+
+        HashMap<String, Reader> readers = new HashMap<>();
+        readers.putAll(oldReaders);
+        readers.putAll(newReaders);
+
+        oldExchange.getMessage().setBody(readers);
+        return oldExchange;
+    }
+
+    public Map<String, Reader> getReaders(Exchange exchange) throws IOException {
+        String readerContent = exchange.getMessage().getBody(String.class);
+        // the exchange variable names are defined in the router.vm file from typhon-rml
+        String readerFormat = exchange.getVariable("readerFormat", String.class);
+        String readerName = exchange.getVariable("readerName", String.class);
+
+        Reader reader = switch (readerFormat) {
+            case "json" -> new JSONReader(readerContent);
+            case "sql" -> {
+                String jdbcDSN = exchange.getVariable("jdbcDSN", String.class);
+                String username = exchange.getVariable("username", String.class);
+                String password = exchange.getVariable("password", String.class);
+                yield new SQLReader(jdbcDSN, username, password);
+            }
+            case "xml" -> {
+                try {
+                    yield new XMLReader(readerContent);
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+            case "csv" -> new CSVReader(readerContent);
+            case "rdf" -> {
+                String sparqlEndpoint = exchange.getVariable("sparqlEndpoint", String.class);
+                if (sparqlEndpoint != null) {
+                    yield new RDFReader(new SPARQLRepository(sparqlEndpoint));
+                }
+                RDFReader rdfReader = new RDFReader();
+                String rmlPath = exchange.getVariable("readerInputFile", String.class);
+                Optional<RDFFormat> rdfFormat = Rio.getParserFormatForFileName(rmlPath);
+                try {
+                    if (rdfFormat.isPresent())
+                        rdfReader.addString(readerContent, rdfFormat.get());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+                yield rdfReader;
+            }
+            default -> throw new InvalidParameterException("Cannot create Reader for format: " + readerFormat);
+        };
+
+        return Map.of(readerName, reader);
+    }
+}

--- a/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptMultipleReadersTest.java
+++ b/camel-chimera-mapping-template/src/test/java/com/cefriel/MaptMultipleReadersTest.java
@@ -1,5 +1,6 @@
 package com.cefriel;
 
+import com.cefriel.aggregationStrategy.ReadersAggregation;
 import com.cefriel.template.io.Reader;
 import com.cefriel.template.io.csv.CSVReader;
 import com.cefriel.util.ChimeraResourceBean;
@@ -11,11 +12,16 @@ import org.apache.camel.test.junit5.CamelTestSupport;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+import java.io.IOException;
 import java.util.Map;
 
 public class MaptMultipleReadersTest extends CamelTestSupport {
     @Produce("direct:start")
     ProducerTemplate start;
+
+    @Produce
+    ProducerTemplate template;
+
 
     private static ChimeraResourceBean templateMultipleReaders;
 
@@ -27,7 +33,7 @@ public class MaptMultipleReadersTest extends CamelTestSupport {
     }
 
     @Test
-    public void testMultipleReaders() throws InterruptedException {
+    public void testMultipleReaders() throws InterruptedException, IOException {
         MockEndpoint mock = getMockEndpoint("mock:multipleReaders");
         mock.expectedMessageCount(1);
 
@@ -43,9 +49,24 @@ public class MaptMultipleReadersTest extends CamelTestSupport {
                         """));
         start.sendBody(readers);
         String result = mock.getExchanges().get(0).getMessage().getBody(String.class);
-        String expectedOutput = "1,2,3,4,5,6".replaceAll("\\r\\n", "\n");
+        String expectedOutput = "1,2,3,4,5,6";
         assert expectedOutput.equals(result);
         mock.assertIsSatisfied();
+    }
+
+    @Test
+    public void testMultipleReadersAggregation() throws InterruptedException, IOException {
+        MockEndpoint mock = getMockEndpoint("mock:multipleReadersAggregation");
+        mock.expectedMessageCount(1);
+
+        template.sendBody("direct:reader1", null);
+        template.sendBody("direct:reader2", null);
+        mock.assertIsSatisfied();
+
+        String result = mock.getExchanges().get(0).getMessage().getBody(String.class);
+        String expectedOutput = "1,2,3,4,5,6";
+        assert expectedOutput.equals(result);
+
     }
 
     @Override
@@ -58,6 +79,30 @@ public class MaptMultipleReadersTest extends CamelTestSupport {
                 from("direct:start")
                         .to("mapt://readers?template=#bean:templateMultipleReaders")
                         .to("mock:multipleReaders");
+
+                from("direct:reader1")
+                        .setVariable("readerFormat", constant("csv"))
+                        .setVariable("readerName", constant("reader1"))
+                        .setBody(constant("""
+                        a,b,c
+                        1,2,3
+                        """))
+                        .to("direct:aggregation");
+
+                from("direct:reader2")
+                        .setVariable("readerFormat", constant("csv"))
+                        .setVariable("readerName", constant("reader2"))
+                        .setBody(constant("""
+                        d,e,f
+                        4,5,6
+                        """))
+                        .to("direct:aggregation");
+
+                from("direct:aggregation")
+                        .aggregate(constant(true), new ReadersAggregation())
+                        .completionSize(2)
+                        .to("mapt://readers?template=#bean:templateMultipleReaders")
+                        .to("mock:multipleReadersAggregation");
             }
         };
     }

--- a/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
+++ b/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-rmlmapper",
-    "version": "4.3.0",
+    "version": "4.3.1-SNAPSHOT",
     "scheme": "rml",
     "extendsScheme": "",
     "syntax": "rml:name",

--- a/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
+++ b/camel-chimera-rmlmapper/src/generated/resources/com/cefriel/component/rml.json
@@ -11,7 +11,7 @@
     "supportLevel": "Stable",
     "groupId": "com.cefriel",
     "artifactId": "camel-chimera-rmlmapper",
-    "version": "4.2.2-SNAPSHOT",
+    "version": "4.3.0",
     "scheme": "rml",
     "extendsScheme": "",
     "syntax": "rml:name",


### PR DESCRIPTION
Moved here from typhon-rml, can be used to create a map of multiple readers from a Camel non Java DSL.