### PR TITLE
force commons-lang3 to 3.17.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ Chimera is currently composed of three Apache Camel Components, available as sub
 - `camel-chimera-rmlmapper` Camel component used to lifting using the [rmlmapper-cefriel](https://github.com/cefriel/rmlmapper-cefriel) library 
 - `camel-chimera-mapping-template` Camel component able to implement both lifting and lowering steps using the [mapping-template](https://github.com/cefriel/mapping-template) library
 
+**N.B.** The `camel-chimera-mapping-template` includes `camel-chimera-graph` as a dependency. Therefore, when using the `camel-chimera-mapping-template` component, you do **not** need to include the `camel-chimera-graph` dependency separately.
+
 ### Chimera Pipeline Configuration
 
 Apache Camel provides support for multiple domain-specific languages

--- a/camel-chimera-graph/pom.xml
+++ b/camel-chimera-graph/pom.xml
@@ -62,6 +62,11 @@
       <version>${camel.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+      <version>3.17.0</version>
+    </dependency>
+    <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-storage</artifactId>
       <type>pom</type>

--- a/camel-chimera-graph/pom.xml
+++ b/camel-chimera-graph/pom.xml
@@ -62,11 +62,6 @@
       <version>${camel.version}</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-lang3</artifactId>
-      <version>3.17.0</version>
-    </dependency>
-    <dependency>
       <groupId>org.eclipse.rdf4j</groupId>
       <artifactId>rdf4j-storage</artifactId>
       <type>pom</type>

--- a/camel-chimera-mapping-template/pom.xml
+++ b/camel-chimera-mapping-template/pom.xml
@@ -53,12 +53,12 @@
   <dependencies>
     <dependency>
       <groupId>com.cefriel</groupId>
-      <artifactId>camel-chimera-graph</artifactId>
+      <artifactId>mapping-template</artifactId>
     </dependency>
     <dependency>
       <groupId>com.cefriel</groupId>
-      <artifactId>mapping-template</artifactId>
-    </dependency>
+      <artifactId>camel-chimera-graph</artifactId>
+    </dependency>    
     <dependency>
       <groupId>org.apache.camel</groupId>
       <artifactId>camel-test-junit5</artifactId>


### PR DESCRIPTION
For the graph component, forces the common-lang3 dependency to version 3.17.0. The conflict was with the rdf4j-storage dependency which pulled in version 3.12.0 of the same library. 

Because we are bumping to the same major version of the library i do not think that this will lead to any issues, WDYT?

closes #57 and adresses #54